### PR TITLE
[FIX] -  Correção da atualização e fechamento de pedidos e itens de pedido

### DIFF
--- a/OutfitTrack.Application/Services/Base/BaseService.cs
+++ b/OutfitTrack.Application/Services/Base/BaseService.cs
@@ -55,7 +55,7 @@ public class BaseService<TIBaseRepository, TInputCreate, TInputUpdate, TEntity, 
     #region Update
     public virtual TOutput Update(long id, TInputUpdate inputUpdate)
     {
-        var oldEntity = _repository!.Get(x => x.Id == id) ?? throw new KeyNotFoundException("Id inválido ou inexistente. Processo: Update");
+        var oldEntity = _repository!.Get(x => x.Id == id) ?? throw new KeyNotFoundException("Id inválido ou inexistente.");
 
         var updatedEntity = UpdateEntity(oldEntity, inputUpdate);
         var result = _repository!.Update(oldEntity) ?? throw new InvalidOperationException("Falha ao atualizar a entidade.");
@@ -83,7 +83,7 @@ public class BaseService<TIBaseRepository, TInputCreate, TInputUpdate, TEntity, 
     #region Delete
     public virtual bool Delete(long id)
     {
-        var entity = _repository!.Get(x => x.Id == id) ?? throw new KeyNotFoundException("Id inválido ou inexistente. Processo: Delete");
+        var entity = _repository!.Get(x => x.Id == id) ?? throw new KeyNotFoundException("Id inválido ou inexistente.");
         _repository.Delete(entity);
         _unitOfWork!.Commit();
 

--- a/OutfitTrack.Domain/Entities/Base/BaseEntity.cs
+++ b/OutfitTrack.Domain/Entities/Base/BaseEntity.cs
@@ -13,14 +13,14 @@ public class BaseEntity<TEntity> : BaseSetProperty<TEntity>
 
     public TEntity SetCreateData()
     {
-        CreationDate = DateTime.Now;
+        CreationDate = DateTime.UtcNow;
 
         return (this as TEntity)!;
     }
 
     public TEntity SetUpdateData()
     {
-        ChangeDate = DateTime.Now;
+        ChangeDate = DateTime.UtcNow;
 
         return (this as TEntity)!;
     }

--- a/OutfitTrack.Infraestructure/Maps/Order/OrderItem/OrderItemMap.cs
+++ b/OutfitTrack.Infraestructure/Maps/Order/OrderItem/OrderItemMap.cs
@@ -11,7 +11,7 @@ public class OrderItemMap : IEntityTypeConfiguration<OrderItem>
         builder.ToTable("pedido_item");
 
         builder.HasOne(x => x.Order).WithMany(x => x.ListOrderItem).HasForeignKey(x => x.OrderId);
-        builder.HasOne(x => x.Product).WithMany(x => x.ListOrderItem).HasForeignKey(x => x.ProductId);
+        builder.HasOne(x => x.Product).WithMany(x => x.ListOrderItem).HasForeignKey(x => x.ProductId).OnDelete(DeleteBehavior.Restrict);
 
         builder.HasKey(x => x.Id);
 

--- a/OutfitTrack.Infraestructure/Maps/Order/OrderMap.cs
+++ b/OutfitTrack.Infraestructure/Maps/Order/OrderMap.cs
@@ -11,7 +11,7 @@ public class OrderMap : IEntityTypeConfiguration<Order>
         builder.ToTable("pedido");
 
         builder.HasMany(x => x.ListOrderItem).WithOne(x => x.Order).HasForeignKey(x => x.OrderId).OnDelete(DeleteBehavior.Cascade);
-        builder.HasOne(x => x.Customer).WithMany(x => x.ListOrder).HasForeignKey(x => x.CustomerId);
+        builder.HasOne(x => x.Customer).WithMany(x => x.ListOrder).HasForeignKey(x => x.CustomerId).OnDelete(DeleteBehavior.Restrict);
 
         builder.HasKey(x => x.Id);
 


### PR DESCRIPTION
- Alterações para corrigir o erro "The instance of entity type 'Order' cannot be tracked because another instance with the same key value for {'Id'} is already being tracked. When attaching existing entities, ensure that only one entity instance with a given key value is attached. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the conflicting key values"